### PR TITLE
use object values instead of spread to handle empty

### DIFF
--- a/frontend/src/components/ViewRooms/reducer.ts
+++ b/frontend/src/components/ViewRooms/reducer.ts
@@ -17,7 +17,7 @@ const reducer = (
   const { type, payload } = action;
   switch (type) {
     case FETCH_ROOMS:
-      return { ...state, rooms: [...payload] };
+      return { ...state, rooms: Object.values(payload) };
     default:
       return state;
   }


### PR DESCRIPTION
Seems like spread of empty objects ain't as smooth as thought. Even tho I tested it... :face_with_head_bandage: 