### PR TITLE
Added local user state

### DIFF
--- a/frontend/src/utils/userManager.tsx
+++ b/frontend/src/utils/userManager.tsx
@@ -5,18 +5,13 @@ import { DATAPORTEN_CLIENT_ID } from '../config';
 // Configuration for dataporten with the properties it need.
 const userManagerConfig = {
   authority: 'https://auth.dataporten.no',
-  automaticSilentRenew: false,
   client_id: DATAPORTEN_CLIENT_ID,
   filterProtocolClaims: true,
   loadUserInfo: true,
   redirect_uri: `${window.location.protocol}//` +
     `${window.location.hostname}${window.location.port ? `:${window.location.port}` : ''}/callback`,
   response_type: 'code',
-  scope: 'email openid profile userid userid-feide groups longterm',
-  silent_redirect_uri: `${window.location.protocol}//` +
-    `${window.location.hostname}${window.location.port
-      ? `:${window.location.port}` : ''
-    } / silent_renew.html`,
+  scope: 'email openid profile userid userid-feide groups',
   userStore: new Oidc.WebStorageStateStore({ store: window.localStorage }),
 };
 

--- a/frontend/src/utils/userManager.tsx
+++ b/frontend/src/utils/userManager.tsx
@@ -1,3 +1,4 @@
+import Oidc from 'oidc-client';
 import { createUserManager } from 'redux-oidc';
 import { DATAPORTEN_CLIENT_ID } from '../config';
 
@@ -16,6 +17,7 @@ const userManagerConfig = {
     `${window.location.hostname}${window.location.port
       ? `:${window.location.port}` : ''
     } / silent_renew.html`,
+  userStore: new Oidc.WebStorageStateStore({ store: window.localStorage }),
 };
 
 const userManager = createUserManager(userManagerConfig);


### PR DESCRIPTION
Added token storage locally. Also, since silent renew functionality is disabled on Dataporten, this will not be implemented. But an 8 hour window on site functionality should be enough, the 'longterm' scope has been removed.